### PR TITLE
Tune up to devel Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,22 +5,25 @@
 #
 # To run:
 #	docker run -it --name niceman \
-#		-v /path/to/your/local/niceman:/niceman \
+#		-v $PWD:/root/niceman \
 #		-v /var/run/docker.sock:/var/run/docker.sock \
 #		niceman:latest
  
 FROM debian:jessie
 #FROM ubuntu:xenial
 
-COPY . /niceman
-COPY docker/niceman.cfg /root
-
 RUN apt-get update \
     && apt-get install -y build-essential libssl-dev libffi-dev vim wget \
     && apt-get install -y python-dev python-pyparsing python-crypto python-pip \
-    && pip install --upgrade pip \
-    && pip install setuptools==33.1.1 pytest docker-py boto3 dockerpty nose \
-    && pip install -e /niceman
+    && pip install --upgrade pip
+
+
+COPY . /root/niceman
+COPY docker/niceman.cfg /root
+
+# TODO: create a matching user here so we could bind mount and develop
+# within docker environment
+RUN pip install -e '/root/niceman[devel]'
 
 WORKDIR /root
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ requires = {
         'tqdm',
         'paramiko',
         'cryptography>=1.5',
-        'enum34',
         'pytz',
         'scp',
         'pycrypto',


### PR DESCRIPTION
- separated out apt-get installations from pip install so could possibly reuse previous step
- all pip depends should be spelled out in setup.py and not require additional pip install
- then seems to be ok and not require enum34 explicitly spelled out
- left TODO note about ideally being able to stay in the same user

Please check if works for you